### PR TITLE
feat(contacts): add update support

### DIFF
--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -516,7 +516,7 @@ const _EXTENDED_TOOLS: ExtendedTool[] = [
   {
     name: 'contacts_people',
     description:
-      'Manages Apple Contacts. Supports reading all contacts, searching by name/email/phone, and creating new contacts.',
+      'Manages Apple Contacts. Supports reading all contacts, searching by name/email/phone, creating new contacts, and updating existing contacts.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -528,7 +528,7 @@ const _EXTENDED_TOOLS: ExtendedTool[] = [
         id: {
           type: 'string',
           description:
-            'The unique identifier of the contact (optional for read to get single contact).',
+            'The unique identifier of the contact (REQUIRED for update; optional for read to get single contact).',
         },
         search: {
           type: 'string',
@@ -537,19 +537,19 @@ const _EXTENDED_TOOLS: ExtendedTool[] = [
         },
         firstName: {
           type: 'string',
-          description: 'First name for the contact (for create).',
+          description: 'First name for the contact (for create/update).',
         },
         lastName: {
           type: 'string',
-          description: 'Last name for the contact (for create).',
+          description: 'Last name for the contact (for create/update).',
         },
         organization: {
           type: 'string',
-          description: 'Organization/company name (for create).',
+          description: 'Organization/company name (for create/update).',
         },
         jobTitle: {
           type: 'string',
-          description: 'Job title (for create).',
+          description: 'Job title (for create/update).',
         },
         email: {
           type: 'string',
@@ -597,7 +597,7 @@ const _EXTENDED_TOOLS: ExtendedTool[] = [
         },
         note: {
           type: 'string',
-          description: 'Notes for the contact (for create).',
+          description: 'Notes for the contact (for create/update).',
         },
         limit: {
           type: 'number',
@@ -621,6 +621,10 @@ const _EXTENDED_TOOLS: ExtendedTool[] = [
             },
             {
               properties: { action: { const: 'create' } },
+            },
+            {
+              properties: { action: { const: 'update' } },
+              required: ['id'],
             },
           ],
         },

--- a/src/tools/handlers/index.ts
+++ b/src/tools/handlers/index.ts
@@ -14,6 +14,7 @@ export {
   handleCreateContact,
   handleReadContacts,
   handleSearchContacts,
+  handleUpdateContact,
 } from './contactsHandlers.js';
 export {
   handleCreateReminderList,

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -42,6 +42,7 @@ import {
   handleReadReminders,
   handleSearchContacts,
   handleUpdateCalendarEvent,
+  handleUpdateContact,
   handleUpdateMail,
   handleUpdateNote,
   handleUpdateReminder,
@@ -177,6 +178,7 @@ const TOOL_ROUTER_MAP = {
       read: (contactsArgs) => handleReadContacts(contactsArgs),
       search: (contactsArgs) => handleSearchContacts(contactsArgs),
       create: (contactsArgs) => handleCreateContact(contactsArgs),
+      update: (contactsArgs) => handleUpdateContact(contactsArgs),
     },
   ),
 } satisfies Record<ToolName, ToolRouter>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -244,12 +244,13 @@ export interface MessagesToolArgs extends BaseToolArgs {
 
 // --- Contacts ---
 
-export type ContactsAction = 'read' | 'search' | 'create';
+export type ContactsAction = 'read' | 'search' | 'create' | 'update';
 
 export const CONTACTS_ACTIONS: readonly ContactsAction[] = [
   'read',
   'search',
   'create',
+  'update',
 ] as const;
 
 /**

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -361,6 +361,27 @@ export const CreateContactSchema = z
     message: 'At least one of firstName, lastName, or organization is required',
   });
 
+export const UpdateContactSchema = z.object({
+  id: SafeIdSchema,
+  firstName: createOptionalSafeTextSchema(
+    VALIDATION.MAX_TITLE_LENGTH,
+    'First name',
+  ),
+  lastName: createOptionalSafeTextSchema(
+    VALIDATION.MAX_TITLE_LENGTH,
+    'Last name',
+  ),
+  organization: createOptionalSafeTextSchema(
+    VALIDATION.MAX_TITLE_LENGTH,
+    'Organization',
+  ),
+  jobTitle: createOptionalSafeTextSchema(
+    VALIDATION.MAX_TITLE_LENGTH,
+    'Job title',
+  ),
+  note: SafeNoteSchema,
+});
+
 /**
  * Validation error wrapper for consistent error handling across the application
  * @extends Error


### PR DESCRIPTION
## Summary

- Add update action to `contacts_people` tool
- Supports updating: firstName, lastName, organization, jobTitle, note
- Uses JXA to modify existing contacts in Apple Contacts app

## Test plan

- [ ] Test updating a contact's first name
- [ ] Test updating a contact's organization
- [ ] Test updating a contact's note field
- [ ] Verify contact ID remains unchanged after update

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)