### PR TITLE
feat(calendar): add recurrence rules support

### DIFF
--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -164,7 +164,7 @@ const _EXTENDED_TOOLS: ExtendedTool[] = [
   {
     name: 'calendar_events',
     description:
-      'Manages calendar events (time blocks). Supports reading, creating, updating, and deleting calendar events.',
+      'Manages calendar events (time blocks). Supports reading, creating, updating, and deleting calendar events, including recurring events.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -216,6 +216,28 @@ const _EXTENDED_TOOLS: ExtendedTool[] = [
           type: 'string',
           description:
             'The name of the calendar for create or update operations.',
+        },
+        // Recurrence properties
+        recurrence: {
+          type: 'string',
+          enum: ['daily', 'weekly', 'monthly', 'yearly'],
+          description:
+            'Recurrence frequency for the event (for create/update).',
+        },
+        recurrenceInterval: {
+          type: 'number',
+          description:
+            'How often the event recurs (e.g., 2 = every 2 days/weeks/months/years). Default: 1.',
+        },
+        recurrenceEnd: {
+          type: 'string',
+          description:
+            "End date for recurrence in 'YYYY-MM-DD' format. Specify either recurrenceEnd or recurrenceCount, not both.",
+        },
+        recurrenceCount: {
+          type: 'number',
+          description:
+            'Number of occurrences for the recurrence. Specify either recurrenceEnd or recurrenceCount, not both.',
         },
         // Read filters
         filterCalendar: {

--- a/src/tools/handlers.test.ts
+++ b/src/tools/handlers.test.ts
@@ -281,6 +281,7 @@ describe('Tool Handlers', () => {
         location: null,
         url: null,
         isAllDay: false,
+        recurrence: null,
       };
       mockCalendarRepository.createEvent.mockResolvedValue(mockEvent);
       const result = await handleCreateCalendarEvent({
@@ -308,6 +309,7 @@ describe('Tool Handlers', () => {
         location: null,
         url: null,
         isAllDay: false,
+        recurrence: null,
       };
       mockCalendarRepository.updateEvent.mockResolvedValue(mockEvent);
       const result = await handleUpdateCalendarEvent({

--- a/src/tools/handlers/calendarHandlers.ts
+++ b/src/tools/handlers/calendarHandlers.ts
@@ -58,6 +58,14 @@ export const handleCreateCalendarEvent = async (
       args,
       CreateCalendarEventSchema,
     );
+    const recurrence = validatedArgs.recurrence
+      ? {
+          frequency: validatedArgs.recurrence,
+          interval: validatedArgs.recurrenceInterval,
+          endDate: validatedArgs.recurrenceEnd,
+          occurrenceCount: validatedArgs.recurrenceCount,
+        }
+      : undefined;
     const event = await calendarRepository.createEvent({
       title: validatedArgs.title,
       startDate: validatedArgs.startDate,
@@ -67,6 +75,7 @@ export const handleCreateCalendarEvent = async (
       location: validatedArgs.location,
       url: validatedArgs.url,
       isAllDay: validatedArgs.isAllDay,
+      recurrence,
     });
     return formatSuccessMessage('created', 'event', event.title, event.id);
   }, 'create calendar event');
@@ -80,6 +89,14 @@ export const handleUpdateCalendarEvent = async (
       args,
       UpdateCalendarEventSchema,
     );
+    const recurrence = validatedArgs.recurrence
+      ? {
+          frequency: validatedArgs.recurrence,
+          interval: validatedArgs.recurrenceInterval,
+          endDate: validatedArgs.recurrenceEnd,
+          occurrenceCount: validatedArgs.recurrenceCount,
+        }
+      : undefined;
     const event = await calendarRepository.updateEvent({
       id: validatedArgs.id,
       title: validatedArgs.title,
@@ -90,6 +107,7 @@ export const handleUpdateCalendarEvent = async (
       location: validatedArgs.location,
       url: validatedArgs.url,
       isAllDay: validatedArgs.isAllDay,
+      recurrence,
     });
     return formatSuccessMessage('updated', 'event', event.title, event.id);
   }, 'update calendar event');

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,6 +25,16 @@ export interface ReminderList {
 }
 
 /**
+ * Recurrence rule interface
+ */
+export interface Recurrence {
+  frequency: 'daily' | 'weekly' | 'monthly' | 'yearly';
+  interval: number;
+  endDate?: string;
+  occurrenceCount?: number;
+}
+
+/**
  * Calendar event interface
  */
 export interface CalendarEvent {
@@ -37,6 +47,7 @@ export interface CalendarEvent {
   location?: string;
   url?: string;
   isAllDay: boolean;
+  recurrence?: Recurrence;
 }
 
 /**
@@ -154,6 +165,11 @@ export interface CalendarToolArgs extends BaseToolArgs {
   isAllDay?: boolean;
   // Target calendar for create/update operations
   targetCalendar?: string;
+  // Recurrence parameters
+  recurrence?: 'daily' | 'weekly' | 'monthly' | 'yearly';
+  recurrenceInterval?: number;
+  recurrenceEnd?: string;
+  recurrenceCount?: number;
 }
 
 export interface CalendarsToolArgs extends BaseToolArgs {

--- a/src/types/repository.ts
+++ b/src/types/repository.ts
@@ -22,6 +22,13 @@ export interface ListJSON {
   title: string;
 }
 
+export interface RecurrenceJSON {
+  frequency: string;
+  interval: number;
+  endDate: string | null;
+  occurrenceCount: number | null;
+}
+
 export interface EventJSON {
   id: string;
   title: string;
@@ -32,6 +39,7 @@ export interface EventJSON {
   location: string | null;
   url: string | null;
   isAllDay: boolean;
+  recurrence: RecurrenceJSON | null;
 }
 
 export interface CalendarJSON {
@@ -75,6 +83,13 @@ export interface UpdateReminderData {
   dueDate?: string;
 }
 
+export interface RecurrenceData {
+  frequency: 'daily' | 'weekly' | 'monthly' | 'yearly';
+  interval?: number;
+  endDate?: string;
+  occurrenceCount?: number;
+}
+
 export interface CreateEventData {
   title: string;
   startDate: string;
@@ -84,6 +99,7 @@ export interface CreateEventData {
   location?: string;
   url?: string;
   isAllDay?: boolean;
+  recurrence?: RecurrenceData;
 }
 
 export interface UpdateEventData {
@@ -96,4 +112,5 @@ export interface UpdateEventData {
   location?: string;
   url?: string;
   isAllDay?: boolean;
+  recurrence?: RecurrenceData;
 }

--- a/src/utils/calendarRepository.ts
+++ b/src/utils/calendarRepository.ts
@@ -15,6 +15,7 @@ import { executeCli } from './cliExecutor.js';
 import {
   addOptionalArg,
   addOptionalBooleanArg,
+  addOptionalNumberArg,
   nullToUndefined,
 } from './helpers.js';
 
@@ -86,6 +87,13 @@ class CalendarRepository {
     addOptionalArg(args, '--location', data.location);
     addOptionalArg(args, '--url', data.url);
     addOptionalBooleanArg(args, '--isAllDay', data.isAllDay);
+    // Recurrence parameters
+    if (data.recurrence) {
+      addOptionalArg(args, '--recurrence', data.recurrence.frequency);
+      addOptionalNumberArg(args, '--recurrenceInterval', data.recurrence.interval);
+      addOptionalArg(args, '--recurrenceEnd', data.recurrence.endDate);
+      addOptionalNumberArg(args, '--recurrenceCount', data.recurrence.occurrenceCount);
+    }
 
     return executeCli<EventJSON>(args);
   }
@@ -100,6 +108,13 @@ class CalendarRepository {
     addOptionalArg(args, '--location', data.location);
     addOptionalArg(args, '--url', data.url);
     addOptionalBooleanArg(args, '--isAllDay', data.isAllDay);
+    // Recurrence parameters
+    if (data.recurrence) {
+      addOptionalArg(args, '--recurrence', data.recurrence.frequency);
+      addOptionalNumberArg(args, '--recurrenceInterval', data.recurrence.interval);
+      addOptionalArg(args, '--recurrenceEnd', data.recurrence.endDate);
+      addOptionalNumberArg(args, '--recurrenceCount', data.recurrence.occurrenceCount);
+    }
 
     return executeCli<EventJSON>(args);
   }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -34,6 +34,19 @@ export function addOptionalBooleanArg(
 }
 
 /**
+ * Adds an optional number argument to the args array if the value is defined
+ */
+export function addOptionalNumberArg(
+  args: string[],
+  flag: string,
+  value: number | undefined,
+): void {
+  if (value !== undefined) {
+    args.push(flag, String(value));
+  }
+}
+
+/**
  * Type conversion utilities
  */
 

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -161,6 +161,18 @@ export const DeleteReminderSchema = z.object({
   id: SafeIdSchema,
 });
 
+// Recurrence schema
+export const RecurrenceSchema = z
+  .object({
+    frequency: z.enum(['daily', 'weekly', 'monthly', 'yearly']),
+    interval: z.number().int().min(1).max(99).optional().default(1),
+    endDate: SafeDateSchema,
+    occurrenceCount: z.number().int().min(1).max(999).optional(),
+  })
+  .refine((data) => !(data.endDate && data.occurrenceCount), {
+    message: 'Specify either endDate or occurrenceCount, not both',
+  });
+
 // Calendar event schemas
 export const CreateCalendarEventSchema = z.object({
   title: SafeTextSchema,
@@ -174,6 +186,10 @@ export const CreateCalendarEventSchema = z.object({
   url: SafeUrlSchema,
   isAllDay: z.boolean().optional(),
   targetCalendar: SafeListNameSchema,
+  recurrence: z.enum(['daily', 'weekly', 'monthly', 'yearly']).optional(),
+  recurrenceInterval: z.number().int().min(1).max(99).optional(),
+  recurrenceEnd: SafeDateSchema,
+  recurrenceCount: z.number().int().min(1).max(999).optional(),
 });
 
 export const ReadCalendarEventsSchema = z.object({
@@ -197,6 +213,10 @@ export const UpdateCalendarEventSchema = z.object({
   url: SafeUrlSchema,
   isAllDay: z.boolean().optional(),
   targetCalendar: SafeListNameSchema,
+  recurrence: z.enum(['daily', 'weekly', 'monthly', 'yearly']).optional(),
+  recurrenceInterval: z.number().int().min(1).max(99).optional(),
+  recurrenceEnd: SafeDateSchema,
+  recurrenceCount: z.number().int().min(1).max(999).optional(),
 });
 
 export const DeleteCalendarEventSchema = z.object({


### PR DESCRIPTION
## Summary

- Add recurrence parameters to `calendar_events` tool for create/update actions
- Supports frequencies: daily, weekly, monthly, yearly
- Configurable interval, end date, or occurrence count
- Recurrence info included when reading events

### New parameters

| Parameter | Type | Description |
|-----------|------|-------------|
| `recurrence` | string | Frequency: daily, weekly, monthly, yearly |
| `recurrenceInterval` | number | How often event recurs (default: 1) |
| `recurrenceEnd` | string | End date in YYYY-MM-DD format |
| `recurrenceCount` | number | Number of occurrences |

### Changes

**Swift EventKit:**
- Add `RecurrenceJSON` struct for serialization
- Handle recurrence in `createEvent` and `updateEvent`
- Serialize recurrence rules when reading events

**TypeScript:**
- Add `Recurrence` interface and `RecurrenceData` type
- Add recurrence validation schema
- Update `calendarRepository` to pass recurrence args
- Update tool definitions with new properties

## Test plan

- [ ] Create daily recurring event
- [ ] Create weekly recurring event with interval (e.g., every 2 weeks)
- [ ] Create recurring event with end date
- [ ] Create recurring event with occurrence count
- [ ] Update existing event to add recurrence
- [ ] Verify recurrence info in Calendar.app

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)