### PR TITLE
fix(notes): preserve newlines by converting plain text body to HTML

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,6 +186,15 @@ osascript -l JavaScript -e 'Application("Contacts").people.slice(0,5).map(p=>p.n
 - **Mock CLI**: `src/utils/__mocks__/cliExecutor.ts`
 - **Mock JXA**: `src/tools/jxaHandlers.test.ts`
 
+## Development Workflow
+
+This is a public repository. All changes go through branches and pull requests.
+
+1. **Issue first** — file or reference a GitHub issue before starting work
+2. **Feature branch** — branch off `main` with a descriptive name: `fix/notes-newline-rendering`, `feat/calendar-recurring`
+3. **Pull request** — open a PR against `main`, link the issue (`Closes #XX`), and describe what changed
+4. **No direct commits to `main`** — all changes merge via PR
+
 ## Commits
 
 See `~/.claude/CLAUDE.md` for commit guidelines. Use `/commit` skill.


### PR DESCRIPTION
## Summary

- Apple Notes' `n.body` is HTML-native. Assigning plain text with `\n` collapses all newlines into spaces — verified empirically by creating test notes with 4 formats (`<br>`, `<div>`, `<p>`, plain text)
- Add `plainTextToHtml()` helper: escapes HTML entities (`&`, `<`, `>`), converts `\n` → `<br>`
- Apply to create, update (replace), and update (append) paths
- Append now reads `n.body()` for HTML concat (preserves existing rich text) while using `n.plaintext()` for length validation
- Add "Development Workflow" section to CLAUDE.md (branch + PR convention for public repo)

Closes #95

## Test plan

- [x] 867 unit tests pass (12 new: 9 for `plainTextToHtml`, 3 for HTML output in handlers)
- [ ] Manual: create multi-line note via MCP, verify line breaks render in Apple Notes
- [ ] Manual: append to existing note, verify existing content preserved + new content has line breaks
- [ ] E2E: `pnpm test:e2e` passes (reads via `n.plaintext()` unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)