### PR TITLE
chore(polish): pre-public launch cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,4 +365,4 @@ MIT
 
 ## Contributing
 
-Contributions welcome! Please read the contributing guidelines first.
+Contributions welcome! Please read the [contributing guidelines](CONTRIBUTING.md) first.

--- a/package.json
+++ b/package.json
@@ -63,12 +63,10 @@
     "prepublishOnly": "pnpm build && pnpm test"
   },
   "dependencies": {
-    "@hono/node-server": "^1.19.9",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "exit-on-epipe": "^1.0.1",
     "express": "^5.2.1",
     "express-rate-limit": "^8.2.1",
-    "hono": "^4.11.9",
     "jose": "^6.1.3",
     "tsx": "^4.21.0",
     "zod": "^4.3.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@hono/node-server':
-        specifier: ^1.19.9
-        version: 1.19.9(hono@4.11.9)
       '@modelcontextprotocol/sdk':
         specifier: ^1.26.0
         version: 1.26.0(zod@4.3.6)
@@ -23,9 +20,6 @@ importers:
       express-rate-limit:
         specifier: ^8.2.1
         version: 8.2.1(express@5.2.1)
-      hono:
-        specifier: ^4.11.9
-        version: 4.11.9
       jose:
         specifier: ^6.1.3
         version: 6.1.3


### PR DESCRIPTION
## Summary
- Link `CONTRIBUTING.md` in README (was plain text, now a markdown link)
- Standardize `mailHandlers.ts` JXA scripts to use `buildScript()` instead of inline `.replace()`, matching the pattern in notesHandlers, contactsHandlers, and messagesHandlers
- Remove unused `hono` and `@hono/node-server` dependencies (Express is the active HTTP framework)

Closes #93

## Test plan
- [x] `pnpm build` — clean, no broken imports
- [x] `pnpm test` — 893/893 pass
- [x] No `hono` references remain in source
- [x] No inline `.replace({{...}})` calls remain in mailHandlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)