### PR TITLE
fix(security): HN hardening pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ All tools support both underscore (`reminders_tasks`) and dot (`reminders.tasks`
 
 ### Prerequisites
 
-- **Node.js 18 or later**
+- **Node.js 20 or later**
 - **macOS** (required for EventKit and JXA)
 - **Xcode Command Line Tools** (required for compiling Swift code)
 - **pnpm** (recommended for package management)
@@ -347,9 +347,9 @@ Run `pnpm test -- src/server/prompts.test.ts` to validate prompt metadata and sc
 
 ### Dependencies
 
-**Runtime:** `@modelcontextprotocol/sdk`, `exit-on-epipe`, `tsx`, `zod`
+**Runtime:** `@modelcontextprotocol/sdk`, `express`, `jose`, `zod`
 
-**Dev:** `typescript`, `jest`, `ts-jest`, `babel-jest`, `@biomejs/biome`
+**Dev:** `typescript`, `tsx`, `jest`, `ts-jest`, `babel-jest`, `@biomejs/biome`
 
 ## License
 

--- a/STATE.md
+++ b/STATE.md
@@ -1,6 +1,6 @@
 # Project State
 
-Last updated: 2026-02-17 (v2.0.3, demo video, .mcp.json cleanup)
+Last updated: 2026-02-20 (v2.1.0, HN hardening pass)
 
 ## Overview
 
@@ -9,7 +9,7 @@ macOS MCP server providing native integration with Reminders, Calendar, Notes, M
 ## Codebase
 
 - **Source**: ~10k LOC TypeScript across `src/`
-- **Tests**: 856 unit tests, 35 test files, all passing
+- **Tests**: 895 unit tests, 35 test files, all passing
 - **E2E**: 149 tests across 8 suites — serial runner (#81 fixed), 2 send skipped
   - 124 stdio transport tests (7 suites)
   - 25 HTTP transport tests (1 suite) — validates full Claude iOS/web path
@@ -89,7 +89,7 @@ Real-world testing from Claude iOS via Cloudflare Tunnel (`mcp.kyleos.ai`). 26 t
 
 ## Unit Test Assessment
 
-856 tests across 35 files. Coverage thresholds: 95/80/95/95 (stmts/branches/functions/lines) — actual: **95.2%/81.7%/97.8%/95.5%**. All above thresholds. `pnpm test --coverage` exits 0.
+895 tests across 35 files. Coverage thresholds: 95/80/95/95 (stmts/branches/functions/lines). All above thresholds. `pnpm test --coverage` exits 0.
 
 | Layer | Confidence | Why |
 |-------|-----------|-----|
@@ -212,6 +212,6 @@ HTTP tests run separately: `pnpm test:e2e:http` (spawns HTTP server on port 4847
 
 - **Production**: LaunchAgent `com.macos-mcp.server` on Mac Mini (migrated from MacBook 2026-02-13)
 - **Tunnel**: Cloudflare Tunnel `mac-mini-winston` → `mcp.kyleos.ai` → `localhost:3847`
-- **npm**: Published as `mcp-macos` (v2.0.3), install via `npm install -g mcp-macos`
+- **npm**: Published as `mcp-macos` (v2.1.0), install via `npm install -g mcp-macos`
 - **CI**: GitHub Actions — test + lint + release (#86 CLOSED)
 - **After restart**: Always restart both server AND tunnel LaunchAgents

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "!dist/**/*.test.*",
     "!dist/test-setup.*",
     "bin/run.cjs",
-    "bin/dev.cjs",
     "src/swift/EventKitCLI.swift",
     "src/swift/Info.plist",
     "scripts/build-swift.mjs",
@@ -62,13 +61,14 @@
     "postinstall": "node -e \"process.platform === 'darwin' && require('child_process').execSync('node scripts/build-swift.mjs', {stdio: 'inherit'})\"",
     "prepublishOnly": "pnpm build && pnpm test"
   },
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",
-    "exit-on-epipe": "^1.0.1",
     "express": "^5.2.1",
     "express-rate-limit": "^8.2.1",
     "jose": "^6.1.3",
-    "tsx": "^4.21.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -81,6 +81,7 @@
     "@types/node": "^25.2.3",
     "@types/supertest": "^6.0.3",
     "babel-jest": "^30.2.0",
+    "tsx": "^4.21.0",
     "babel-plugin-transform-import-meta": "^2.3.3",
     "jest": "^30.2.0",
     "semantic-release": "^25.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.26.0
         version: 1.26.0(zod@4.3.6)
-      exit-on-epipe:
-        specifier: ^1.0.1
-        version: 1.0.1
       express:
         specifier: ^5.2.1
         version: 5.2.1
@@ -23,9 +20,6 @@ importers:
       jose:
         specifier: ^6.1.3
         version: 6.1.3
-      tsx:
-        specifier: ^4.21.0
-        version: 4.21.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -72,6 +66,9 @@ importers:
       ts-jest:
         specifier: ^29.4.6
         version: 29.4.6(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@30.2.0(@types/node@25.2.3))(typescript@5.9.3)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1933,10 +1930,6 @@ packages:
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
-
-  exit-on-epipe@1.0.1:
-    resolution: {integrity: sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==}
-    engines: {node: '>=0.8'}
 
   exit-x@0.2.2:
     resolution: {integrity: sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==}
@@ -5756,8 +5749,6 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
-
-  exit-on-epipe@1.0.1: {}
 
   exit-x@0.2.2: {}
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -3,11 +3,16 @@
  * Server configuration and startup logic
  */
 
-import 'exit-on-epipe';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import type { ServerConfig } from '../types/index.js';
 import { registerHandlers } from './handlers.js';
+
+// Gracefully exit on EPIPE (broken pipe) when the MCP client disconnects.
+// Replaces the `exit-on-epipe` npm package with an inline equivalent.
+process.stdout?.on?.('error', (err: NodeJS.ErrnoException) => {
+  if (err.code === 'EPIPE') process.exit(0);
+});
 
 /**
  * Server configuration interface for createServer

--- a/src/utils/sqliteMailReader.test.ts
+++ b/src/utils/sqliteMailReader.test.ts
@@ -411,6 +411,19 @@ describe('getMessageById', () => {
     expect(result?.ccRecipients).toEqual([]);
   });
 
+  it('throws SqliteMailAccessError for non-integer ROWID', async () => {
+    await expect(getMessageById('abc')).rejects.toThrow(SqliteMailAccessError);
+    await expect(getMessageById('abc')).rejects.toThrow('Invalid message ID');
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
+  it('throws SqliteMailAccessError for injection attempt in ROWID', async () => {
+    await expect(getMessageById('1; DROP TABLE messages--')).rejects.toThrow(
+      'Invalid message ID',
+    );
+    expect(mockExecFile).not.toHaveBeenCalled();
+  });
+
   it('handles null to_addresses and cc_addresses', async () => {
     const row = makeRawMailFullRow({
       to_addresses: null,

--- a/src/utils/sqliteMailReader.ts
+++ b/src/utils/sqliteMailReader.ts
@@ -325,7 +325,9 @@ export async function searchBySenderName(
 export async function getMessageById(
   rowId: string,
 ): Promise<MailMessageFull | null> {
-  const escaped = escapeSql(rowId);
+  if (!/^\d+$/.test(rowId))
+    throw new SqliteMailAccessError('Invalid message ID', false);
+  const rowIdNum = Number.parseInt(rowId, 10);
   const query = `
     SELECT m.ROWID, s.subject, a.address, a.comment, m.date_received,
            m.read, mb.url as mailbox_url, sm.summary,
@@ -346,7 +348,7 @@ export async function getMessageById(
     LEFT JOIN addresses a ON m.sender = a.ROWID
     LEFT JOIN mailboxes mb ON m.mailbox = mb.ROWID
     LEFT JOIN summaries sm ON m.summary = sm.ROWID
-    WHERE m.ROWID = ${escaped}
+    WHERE m.ROWID = ${rowIdNum}
   `;
   const output = await runSqlite(query, 10000);
   const rows = parseSqliteJson<RawMailFullRow>(output);

--- a/src/utils/sqliteMessageReader.test.ts
+++ b/src/utils/sqliteMessageReader.test.ts
@@ -536,14 +536,14 @@ describe('sqliteMessageReader reader functions', () => {
       mockSqliteSuccess(JSON.stringify([]));
       await readMessagesByHandles(['user@example.com'], 10);
       expect(mockExecFile).toHaveBeenCalledTimes(1);
-      const queryArg = mockExecFile.mock.calls[0][1][2] as string;
+      const queryArg = mockExecFile.mock.calls[0][1][3] as string;
       expect(queryArg).toContain("h.id = 'user@example.com'");
     });
 
     it('handles phone numbers with LIKE suffix match', async () => {
       mockSqliteSuccess(JSON.stringify([]));
       await readMessagesByHandles(['+15551234567'], 10);
-      const queryArg = mockExecFile.mock.calls[0][1][2] as string;
+      const queryArg = mockExecFile.mock.calls[0][1][3] as string;
       expect(queryArg).toContain("h.id LIKE '%5551234567'");
     });
   });

--- a/src/utils/sqliteMessageReader.ts
+++ b/src/utils/sqliteMessageReader.ts
@@ -25,7 +25,7 @@ function runSqlite(query: string, timeoutMs = 15000): Promise<string> {
   return new Promise((resolve, reject) => {
     execFile(
       '/usr/bin/sqlite3',
-      ['-json', CHAT_DB_PATH, query],
+      ['-json', '-readonly', CHAT_DB_PATH, query],
       { timeout: timeoutMs, maxBuffer: 10 * 1024 * 1024 },
       (error, stdout, stderr) => {
         if (error) {


### PR DESCRIPTION
## Summary

Six targeted changes from a Hacker News-style code review — focused on the findings that were genuinely worth fixing, not optics.

- **Add `-readonly` to Messages SQLite** — the most legitimate security finding. Mail and Contacts already had it; Messages was the only reader opening `chat.db` read-write despite only running SELECTs
- **Inline `exit-on-epipe`** — replace a runtime dependency with 3 lines of inline EPIPE handling
- **Move `tsx` to devDependencies** — npm users don't need dev mode; remove `bin/dev.cjs` from published files
- **Add `engines.node >= 20`** — Node 20 is the actual minimum LTS we support
- **Validate ROWID as integer** — `getMessageById()` now rejects non-digit strings before building the query (was using `escapeSql()` on a numeric ID)
- **Update stale STATE.md** — version and test count corrected

### What we reviewed but didn't change (and why)
- **SQL "injection"**: All user input goes through single-quote doubling (SQL-92 standard), consistently applied. Adding `better-sqlite3` would add a native addon dependency for optics alone
- **CORS `*`**: Cloudflare Access JWT auth is the security gate, not origin checking. Multi-client requires permissive CORS
- **Babel in Jest**: Actually needed for `.mjs` mock transforms
- **Biome exact pinning**: Intentional — prevents formatter rule changes from breaking CI

## Test plan

- [x] `pnpm build` — compiles clean
- [x] `pnpm test` — 895 unit tests pass, all coverage thresholds met
- [x] `sqlite3 -readonly ~/Library/Messages/chat.db "SELECT 1"` — succeeds
- [x] `npm pack --dry-run` — confirms `bin/dev.cjs` excluded, `tsx` not in prod deps
- [x] TypeScript type check passes (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)