### PR TITLE
fix(security): JXA injection, auth bypass, AppleScript escaping

### DIFF
--- a/src/tools/handlers/mailHandlers.ts
+++ b/src/tools/handlers/mailHandlers.ts
@@ -88,7 +88,7 @@ const GET_MAIL_SCRIPT_JXA = `
   for (let a = 0; a < accounts.length; a++) {
     const mailboxes = accounts[a].mailboxes();
     for (let b = 0; b < mailboxes.length; b++) {
-      const msgs = mailboxes[b].messages.whose({id: {{id}}})();
+      const msgs = mailboxes[b].messages.whose({id: "{{id}}"})();
       if (msgs.length > 0) {
         const m = msgs[0];
         return JSON.stringify({
@@ -109,10 +109,10 @@ const MARK_READ_SCRIPT = `
   for (let a = 0; a < accounts.length; a++) {
     const mailboxes = accounts[a].mailboxes();
     for (let b = 0; b < mailboxes.length; b++) {
-      const msgs = mailboxes[b].messages.whose({id: {{id}}})();
+      const msgs = mailboxes[b].messages.whose({id: "{{id}}"})();
       if (msgs.length > 0) {
         msgs[0].readStatus = {{readStatus}};
-        return JSON.stringify({updated: true, id: {{id}}, read: {{readStatus}}});
+        return JSON.stringify({updated: true, id: "{{id}}", read: {{readStatus}}});
       }
     }
   }
@@ -127,10 +127,10 @@ const DELETE_MAIL_SCRIPT = `
   for (let a = 0; a < accounts.length; a++) {
     const mailboxes = accounts[a].mailboxes();
     for (let b = 0; b < mailboxes.length; b++) {
-      const msgs = mailboxes[b].messages.whose({id: {{id}}})();
+      const msgs = mailboxes[b].messages.whose({id: "{{id}}"})();
       if (msgs.length > 0) {
         Mail.delete(msgs[0]);
-        return JSON.stringify({deleted: true, id: {{id}}});
+        return JSON.stringify({deleted: true, id: "{{id}}"});
       }
     }
   }

--- a/src/tools/handlers/messagesHandlers.ts
+++ b/src/tools/handlers/messagesHandlers.ts
@@ -15,6 +15,7 @@ import {
   buildScript,
   executeAppleScript,
   executeJxa,
+  sanitizeForJxa,
 } from '../../utils/jxaExecutor.js';
 import {
   type DateRange,
@@ -563,8 +564,8 @@ export async function handleCreateMessage(
 
     const appleScript = `tell application "Messages"
     set targetService to 1st account whose service type = iMessage
-    set targetBuddy to participant "${validated.to.replace(/"/g, '\\"')}" of targetService
-    send "${validated.text.replace(/"/g, '\\"')}" to targetBuddy
+    set targetBuddy to participant "${sanitizeForJxa(validated.to)}" of targetService
+    send "${sanitizeForJxa(validated.text)}" to targetBuddy
 end tell`;
     await executeAppleScript(appleScript, 15000, 'Messages');
     return `Successfully sent message to ${validated.to}.`;

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -134,6 +134,12 @@ const BaseReminderFields = {
 
 export const SafeIdSchema = z.string().min(1, 'ID cannot be empty');
 
+/** Mail IDs are SQLite ROWIDs — always numeric. Defense-in-depth against JXA injection. */
+export const SafeMailIdSchema = z
+  .string()
+  .min(1, 'Mail ID cannot be empty')
+  .regex(/^\d+$/, 'Mail ID must be numeric');
+
 /**
  * Tool-specific validation schemas
  */
@@ -280,7 +286,7 @@ export const CreateNotesFolderSchema = z.object({
 // --- Mail Schemas ---
 
 export const ReadMailSchema = z.object({
-  id: z.string().optional(),
+  id: SafeMailIdSchema.optional(),
   search: SafeSearchSchema,
   mailbox: createOptionalSafeTextSchema(
     VALIDATION.MAX_LIST_NAME_LENGTH,
@@ -304,16 +310,16 @@ export const CreateMailSchema = z.object({
   to: z.array(z.string().email()).min(1, 'At least one recipient required'),
   cc: z.array(z.string().email()).optional(),
   bcc: z.array(z.string().email()).optional(),
-  replyToId: z.string().optional(),
+  replyToId: SafeMailIdSchema.optional(),
 });
 
 export const UpdateMailSchema = z.object({
-  id: SafeIdSchema,
+  id: SafeMailIdSchema,
   read: z.boolean(),
 });
 
 export const DeleteMailSchema = z.object({
-  id: SafeIdSchema,
+  id: SafeMailIdSchema,
 });
 
 // --- Messages Schemas ---


### PR DESCRIPTION
## Summary

Second HN-style security review found 4 bugs rooted in **pattern inconsistency** — the correct pattern existed elsewhere in the codebase but wasn't applied uniformly. Follows AAR-001: "fix the pattern, not the instance."

- **Mail JXA injection (HIGH)**: Unquoted `{id: {{id}}}` in mail JXA templates. Quoted to match contacts/notes/messages. Added `SafeMailIdSchema` (digits-only) for defense-in-depth
- **Auth bypass on `/` (HIGH)**: Root MCP endpoint lacked Cloudflare Access auth. Applied `app.post('/')` / `app.delete('/')` auth without affecting GET `/health`
- **AppleScript injection in message send (HIGH)**: Manual `.replace(/"/g, '\\"')` missed backslashes, single quotes, `$`, Unicode. Replaced with `sanitizeForJxa()`
- **Trust proxy spoofing (MEDIUM)**: `trust proxy: true` → `trust proxy: 1` to trust only first hop (Cloudflare), preventing rate limiter bypass

### NOT doing (and why)
- **`qs` transitive dep DoS**: No upstream fix, MCP uses JSON POST bodies not query strings. Monitor for Express update.

## Verification
- `pnpm build` — compiles clean
- `pnpm test` — 910 tests pass (15 new), coverage thresholds met
- Grep audit: zero unquoted `whose({id: {{` in `src/`
- Grep audit: zero manual quote-only `.replace(/"/g` outside `sanitizeForJxa` itself

## Test plan
- [x] Non-numeric mail ID (`"abc"`) rejected at schema level
- [x] Root `/` POST/DELETE require JWT when Cloudflare Access configured
- [x] Root `/` GET still works without auth (health)
- [x] Message send escapes backslashes, single quotes, dollar signs
- [x] All existing tests pass with numeric mail IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)