### PR TITLE
fix(security): HN review pass 3 — LIKE wildcards, schema gaps, validation

### DIFF
--- a/src/tools/handlers.test.ts
+++ b/src/tools/handlers.test.ts
@@ -135,6 +135,10 @@ describe('Tool Handlers', () => {
       });
       const content = _getTextContent(result.content);
 
+      // Verify the validated id is passed to the repository (not raw args.id)
+      expect(mockReminderRepository.findReminderById).toHaveBeenCalledWith(
+        '456',
+      );
       expect(content).toContain('### Reminder');
       expect(content).toContain('- [x] Completed Task');
       expect(content).toContain('- List: Done');

--- a/src/tools/handlers/messagesHandlers.ts
+++ b/src/tools/handlers/messagesHandlers.ts
@@ -558,16 +558,15 @@ export async function handleCreateMessage(
       return `Successfully sent message to chat "${validated.chatId}".`;
     }
 
-    if (!validated.to) {
-      throw new Error('Either "to" or "chatId" is required to send a message.');
-    }
-
+    // validated.to is guaranteed by CreateMessageSchema.refine() (to || chatId required)
+    // TypeScript can't narrow from .refine(), but chatId was checked above so to must exist
+    const recipient = validated.to as string;
     const appleScript = `tell application "Messages"
     set targetService to 1st account whose service type = iMessage
-    set targetBuddy to participant "${sanitizeForJxa(validated.to)}" of targetService
+    set targetBuddy to participant "${sanitizeForJxa(recipient)}" of targetService
     send "${sanitizeForJxa(validated.text)}" to targetBuddy
 end tell`;
     await executeAppleScript(appleScript, 15000, 'Messages');
-    return `Successfully sent message to ${validated.to}.`;
+    return `Successfully sent message to ${recipient}.`;
   }, 'send message');
 }

--- a/src/tools/handlers/reminderHandlers.ts
+++ b/src/tools/handlers/reminderHandlers.ts
@@ -110,10 +110,10 @@ export const handleReadReminders = async (
   return handleAsyncOperation(async () => {
     const validatedArgs = extractAndValidateArgs(args, ReadRemindersSchema);
 
-    // Check if id is provided in args (before validation)
-    // because id might be filtered out by schema validation if it's optional
-    if (args.id) {
-      const reminder = await reminderRepository.findReminderById(args.id);
+    if (validatedArgs.id) {
+      const reminder = await reminderRepository.findReminderById(
+        validatedArgs.id,
+      );
       const tz = getSystemTimezone();
       const markdownLines: string[] = [
         '### Reminder',

--- a/src/validation/schemas.test.ts
+++ b/src/validation/schemas.test.ts
@@ -6,11 +6,13 @@
 import { z } from 'zod/v3';
 import {
   CreateMailSchema,
+  CreateMessageSchema,
   CreateReminderListSchema,
   CreateReminderSchema,
   DeleteMailSchema,
   DeleteReminderSchema,
   ReadMailSchema,
+  ReadMessagesSchema,
   ReadRemindersSchema,
   RecurrenceSchema,
   RequiredListNameSchema,
@@ -423,6 +425,68 @@ describe('ValidationSchemas', () => {
           replyToId: '123',
         }),
       ).not.toThrow();
+    });
+  });
+
+  describe('CreateMessageSchema', () => {
+    it('accepts valid message with "to"', () => {
+      const result = CreateMessageSchema.safeParse({
+        text: 'Hello',
+        to: '+15551234567',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts valid message with "chatId"', () => {
+      const result = CreateMessageSchema.safeParse({
+        text: 'Hello',
+        chatId: 'iMessage;-;+15551234567',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects when both "to" and "chatId" are missing', () => {
+      const result = CreateMessageSchema.safeParse({
+        text: 'Hello',
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toContain(
+          'Either "to" or "chatId" is required',
+        );
+      }
+    });
+
+    it('rejects chatId exceeding 200 characters', () => {
+      const result = CreateMessageSchema.safeParse({
+        text: 'Hello',
+        chatId: 'x'.repeat(201),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects "to" exceeding 200 characters', () => {
+      const result = CreateMessageSchema.safeParse({
+        text: 'Hello',
+        to: 'x'.repeat(201),
+      });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('ReadMessagesSchema', () => {
+    it('rejects chatId exceeding 200 characters', () => {
+      const result = ReadMessagesSchema.safeParse({
+        chatId: 'x'.repeat(201),
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts chatId within 200 characters', () => {
+      const result = ReadMessagesSchema.safeParse({
+        chatId: 'iMessage;-;+15551234567',
+      });
+      expect(result.success).toBe(true);
     });
   });
 

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -325,7 +325,7 @@ export const DeleteMailSchema = z.object({
 // --- Messages Schemas ---
 
 export const ReadMessagesSchema = z.object({
-  chatId: z.string().optional(),
+  chatId: z.string().max(200).optional(),
   search: SafeSearchSchema,
   searchMessages: z.boolean().optional(),
   enrichContacts: z.boolean().optional().default(true),
@@ -341,11 +341,15 @@ export const ReadMessagesSchema = z.object({
   ...PaginationFields,
 });
 
-export const CreateMessageSchema = z.object({
-  text: z.string().min(1, 'Message text cannot be empty').max(10000),
-  to: z.string().optional(),
-  chatId: z.string().optional(),
-});
+export const CreateMessageSchema = z
+  .object({
+    text: z.string().min(1, 'Message text cannot be empty').max(10000),
+    to: z.string().max(200).optional(),
+    chatId: z.string().max(200).optional(),
+  })
+  .refine((data) => data.to || data.chatId, {
+    message: 'Either "to" or "chatId" is required to send a message',
+  });
 
 // --- Contacts Schemas ---
 


### PR DESCRIPTION
## Summary

Third HN-style security review. No CRITICAL/HIGH issues found — these are MEDIUM/LOW pattern-consistency fixes:

- **Escape LIKE wildcard characters** (`%`, `_`, `\`) in all SQL search functions across `sqliteMailReader` and `sqliteMessageReader`. Without this, searching "50%" matches "500", "5000", etc. Every LIKE query with user input now has `ESCAPE '\'`
- **Add `.max(200)` length constraints** to `chatId` and `to` in `ReadMessagesSchema` / `CreateMessageSchema`, matching the rest of the schema system
- **Add `.refine()` to `CreateMessageSchema`** enforcing `to || chatId` at schema level, removing redundant runtime check in `messagesHandlers.ts`
- **Use `validatedArgs.id` instead of raw `args.id`** in `handleReadReminders` — every other handler uses the validated value

## Test plan

- [x] `pnpm build` — compiles clean
- [x] `pnpm test` — 931 tests pass
- [x] Grep audit: every `LIKE '%...%'` with user input has matching `ESCAPE '\'`
- [x] New unit tests for `escapeLikeWildcards()` in both readers
- [x] New schema tests: `CreateMessageSchema` rejects missing `to`/`chatId`, `.max(200)` enforced
- [x] `handleReadReminders` test verifies `findReminderById` called with validated arg

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)